### PR TITLE
feat: allow controlled start

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,4 +12,10 @@ process.on('unhandledRejection', (reason, p) => {
   }
 })
 
-Server.start()
+if (process.env.AUTO_START) {
+  Server.start()
+}
+
+module.exports = {
+  Server
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@davesag/mock-algolia",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,5 +1,5 @@
 const traverse = require('traverse-folders')
-const pathToRoute = require('src/utils/api/pathToRoute')
+const pathToRoute = require('../utils/api/pathToRoute')
 
 const apis = {}
 

--- a/src/api/ping.js
+++ b/src/api/ping.js
@@ -1,9 +1,9 @@
-const uptime = require('src/utils/uptime')
+const uptime = require('../utils/uptime')
 const {
   apiSummary: {
     info: { name, version, description }
   }
-} = require('src/utils/api/apiDetails')
+} = require('../utils/api/apiDetails')
 
 const ping = (req, res) => {
   res.json({

--- a/src/api/v1/genericUnhandled.js
+++ b/src/api/v1/genericUnhandled.js
@@ -1,5 +1,5 @@
-const logger = require('src/utils/logger')
-const { makeTaskID } = require('src/utils/ids')
+const logger = require('../..utils/logger')
+const { makeTaskID } = require('../../utils/ids')
 
 const genericUnhandled = (req, res) => {
   logger.debug('unhandled route', req.method, req.originalUrl)

--- a/src/api/v1/genericUnhandled.js
+++ b/src/api/v1/genericUnhandled.js
@@ -1,4 +1,4 @@
-const logger = require('../..utils/logger')
+const logger = require('../../utils/logger')
 const { makeTaskID } = require('../../utils/ids')
 
 const genericUnhandled = (req, res) => {

--- a/src/api/v1/indices/addObject.js
+++ b/src/api/v1/indices/addObject.js
@@ -1,5 +1,5 @@
-const logger = require('src/utils/logger')
-const { makeTaskID, makeObjectID } = require('src/utils/ids')
+const logger = require('../../../utils/logger')
+const { makeTaskID, makeObjectID } = require('../../../utils/ids')
 
 /*
 

--- a/src/api/v1/indices/bulkActions.js
+++ b/src/api/v1/indices/bulkActions.js
@@ -1,5 +1,5 @@
-const logger = require('src/utils/logger')
-const { makeTaskID, makeObjectID } = require('src/utils/ids')
+const logger = require('../../../utils/logger')
+const { makeTaskID, makeObjectID } = require('../../../utils/ids')
 
 /*
   handles

--- a/src/api/v1/indices/deleteObject.js
+++ b/src/api/v1/indices/deleteObject.js
@@ -1,5 +1,5 @@
-const logger = require('src/utils/logger')
-const { makeTaskID, makeObjectID } = require('src/utils/ids')
+const logger = require('../../../utils/logger')
+const { makeTaskID, makeObjectID } = require('../../../utils/ids')
 
 /*
 

--- a/src/api/v1/indices/replaceObject.js
+++ b/src/api/v1/indices/replaceObject.js
@@ -1,5 +1,5 @@
-const logger = require('src/utils/logger')
-const { makeTaskID, makeObjectID } = require('src/utils/ids')
+const logger = require('../../../utils/logger')
+const { makeTaskID, makeObjectID } = require('../../../utils/ids')
 
 /*
 

--- a/src/api/v1/indices/updateObject.js
+++ b/src/api/v1/indices/updateObject.js
@@ -1,5 +1,5 @@
-const logger = require('src/utils/logger')
-const { makeTaskID, makeObjectID } = require('src/utils/ids')
+const logger = require('../../../utils/logger')
+const { makeTaskID, makeObjectID } = require('../../../utils/ids')
 
 /*
 

--- a/src/api/v1/indices/updateSettings.js
+++ b/src/api/v1/indices/updateSettings.js
@@ -1,5 +1,5 @@
-const logger = require('src/utils/logger')
-const { makeTaskID } = require('src/utils/ids')
+const logger = require('../../../utils/logger')
+const { makeTaskID } = require('../../../utils/ids')
 
 /*
 

--- a/src/api/v1/indices/waitTask.js
+++ b/src/api/v1/indices/waitTask.js
@@ -1,4 +1,4 @@
-const logger = require('src/utils/logger')
+const logger = require('../../../utils/logger')
 
 /*
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable promise/always-return */
-const Server = require('src/server')
-const logger = require('src/utils/logger')
+const Server = require('./server')
+const logger = require('./utils/logger')
 
 Server.start()
   .then(() => {

--- a/src/server.js
+++ b/src/server.js
@@ -2,11 +2,12 @@ const makeApp = require('src/utils/makeApp')
 const logger = require('src/utils/logger')
 const { PORT } = require('src/utils/config')
 
-const start = async () => {
+const start = async (options = {}) => {
+  const { port = PORT } = options;
   try {
     const app = await makeApp()
-    const server = await app.listen(PORT)
-    logger.debug('Server started. Listening on port', PORT)
+    const server = await app.listen(port)
+    logger.debug('Server started. Listening on port', port)
 
     return { server }
   } catch (err) {

--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,7 @@ const logger = require('./utils/logger')
 const { PORT } = require('./utils/config')
 
 const start = async (options = {}) => {
-  const { port = PORT } = options;
+  const { port = PORT } = options
   try {
     const app = await makeApp()
     const server = await app.listen(port)

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,6 @@
-const makeApp = require('src/utils/makeApp')
-const logger = require('src/utils/logger')
-const { PORT } = require('src/utils/config')
+const makeApp = require('./utils/makeApp')
+const logger = require('./utils/logger')
+const { PORT } = require('./utils/config')
 
 const start = async (options = {}) => {
   const { port = PORT } = options;

--- a/src/utils/api/apiDetails.js
+++ b/src/utils/api/apiDetails.js
@@ -1,7 +1,7 @@
 const YAML = require('yamljs')
 const { summarise } = require('swagger-routes-express')
 
-const apiDefinition = YAML.load('api.yml')
+const apiDefinition = YAML.load('../../../api.yml')
 const apiSummary = summarise(apiDefinition)
 
 module.exports = { apiDefinition, apiSummary }

--- a/src/utils/api/apiDetails.js
+++ b/src/utils/api/apiDetails.js
@@ -1,7 +1,7 @@
 const YAML = require('yamljs')
 const { summarise } = require('swagger-routes-express')
 
-const apiDefinition = YAML.load('../../../api.yml')
+const apiDefinition = YAML.load(`${__dirname}/../../../api.yml`)
 const apiSummary = summarise(apiDefinition)
 
 module.exports = { apiDefinition, apiSummary }

--- a/src/utils/genericErrors.js
+++ b/src/utils/genericErrors.js
@@ -1,7 +1,7 @@
 const { INTERNAL_SERVER_ERROR } = require('http-status-codes')
 
-const logger = require('src/utils/logger')
-const ERRORS = require('src/errors')
+const logger = require('./logger')
+const ERRORS = require('../errors')
 
 const genericErrors = (err, req, res, next) => {
   if (res.headersSent) return next(err)

--- a/src/utils/makeApp.js
+++ b/src/utils/makeApp.js
@@ -4,7 +4,7 @@ const bodyParser = require('body-parser')
 const swaggerUi = require('swagger-ui-express')
 const { connector } = require('swagger-routes-express')
 
-const api = require('src/api')
+const api = require('../api')
 const { apiDefinition } = require('./api/apiDetails')
 
 const genericErrors = require('./genericErrors')

--- a/src/utils/makeApp.js
+++ b/src/utils/makeApp.js
@@ -5,10 +5,10 @@ const swaggerUi = require('swagger-ui-express')
 const { connector } = require('swagger-routes-express')
 
 const api = require('src/api')
-const { apiDefinition } = require('src/utils/api/apiDetails')
+const { apiDefinition } = require('./api/apiDetails')
 
-const genericErrors = require('src/utils/genericErrors')
-const notFoundError = require('src/utils/notFoundError')
+const genericErrors = require('./genericErrors')
+const notFoundError = require('./notFoundError')
 
 const makeApp = async () => {
   const connect = connector(api, apiDefinition)

--- a/src/utils/notFoundError.js
+++ b/src/utils/notFoundError.js
@@ -1,5 +1,5 @@
 const { NOT_FOUND } = require('http-status-codes')
-const ERRORS = require('src/errors')
+const ERRORS = require('../errors')
 
 const notFoundError = (req, res) => {
   res.status(NOT_FOUND).json({ error: ERRORS.UNKNWON_ROUTE })


### PR DESCRIPTION
This PR allows people using your library to run the mock server within their own codebase, rather than as a separate container (if they wish). It also therefore allows passing in an options object with `PORT` override. I had to change your absolute paths to relative as running the library under node_modules was not happy using absolute paths.